### PR TITLE
Add support for Symfony 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     },
     "require": {
-        "php": ">=5.4",
-        "symfony/framework-bundle": "^4.2",
+        "php": ">=7.1",
+        "symfony/framework-bundle": "^4.0 || ^5.0",
         "goodby/csv": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "symfony/framework-bundle": "^2.2 || ^3.0 || ^4.0",
+        "symfony/framework-bundle": "^4.2",
         "goodby/csv": "^1.1"
     },
     "require-dev": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('intriro_csv');
+        $treeBuilder = new TreeBuilder('intriro_csv');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,7 +13,13 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('intriro_csv');
-        $rootNode = $treeBuilder->getRootNode();
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Backwards compatibility for symfony 4.1 and older
+            $rootNode = $treeBuilder->root('intriro_csv');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
TreeBuilder's root() method is deprecated since Symfony 4.3.
The constructor for TreeBuilder was added in symfony/config 4.2, which is a
transitive dependency of symfony/framework-bundle 4.2